### PR TITLE
Bug: Nav Bar blocks top of page and does not close

### DIFF
--- a/components/navbar.js
+++ b/components/navbar.js
@@ -115,7 +115,7 @@ export default function Navbar() {
         </a>
       </div>
 
-      <div className="navbar-menu" ref={navbar}>
+      <div className="navbar-menu" ref={navbar} onClick={showMobileNavbar}>
         <div className="navbar-start">
           <Link href="/products" className="navbar-item">
             Products

--- a/components/navbar.js
+++ b/components/navbar.js
@@ -14,6 +14,28 @@ export default function Navbar() {
     }
   }, [token]);
 
+  // Handle user clicking outside navbar and closing dropdown menu
+  useEffect(() => {
+    const handleOutsideClick = (e) => {
+      // Was the click outside the navbar/menu?
+      if (
+        navbar.current &&
+        !navbar.current.contains(e.target) &&
+        hamburger.current &&
+        !hamburger.current.contains(e.target)
+      ) {
+        // Is the navbar/menu open/is-active? If yes, close the menu
+        if (navbar.current.classList.contains("is-active")) {
+          showMobileNavbar()
+         }
+      }
+    }
+    // Was there a click?
+    document.addEventListener("click", handleOutsideClick);
+    //Unmount after
+    return () => document.removeEventListener("click", handleOutsideClick)
+  }, [])
+
   const showMobileNavbar = () => {
     hamburger.current.classList.toggle("is-active");
     navbar.current.classList.toggle("is-active");


### PR DESCRIPTION
The navbar uses Bulma's is-fixed-top class, which pins it to the top of the viewport. Clicking the hamburger icon opens the navbar menu, but there is no way to close it other than clicking the hamburger again. If a user navigates away or scrolls, the open menu remains open and blocks the top portion of the page content.

## Changes
- added onClick to line 140 so menu knows to close after user clicks on a link in menu/navbar
- added handleOutsideClick function to close navbar/menu when user clicks outside open menu 

## Requests / Responses
No changes to requests/responses

##T esting
- [ ] npm run dev to run server
- [ ] open page and change size of screen till hamburger menu shows up. 
- [ ] click on link in menu to make sure menu closes 
- [ ] repeat but click outside menu to make sure menu closes  

## Related Issues
- Fixes https://github.com/orgs/NSS-Day-Cohort-79/projects/32/views/1?pane=issue&itemId=178628108&issue=NSS-Day-Cohort-79%7CBangazon-api-vezglj%7C53
