### PR TITLE
Fix addProductToOrder function to use correct path and parameters

### DIFF
--- a/data/products.js
+++ b/data/products.js
@@ -30,12 +30,14 @@ export function getProductById(id) {
   });
 }
 
-export function addProductToOrder(id) {
-  return fetchWithResponse(`products/${id}/add_to_order`, {
+export function addProductToOrder(product_id) {
+  return fetchWithResponse(`profile/cart`, {
     method: "POST",
     headers: {
       Authorization: `Token ${localStorage.getItem("token")}`,
+      "Content-Type": "application/json",
     },
+    body: JSON.stringify({ product_id })
   });
 }
 


### PR DESCRIPTION
Adding an item to the cart sends a request to /product/id/add_to_cart instead of /profile/cart with the product id in the body.

## Changes
- changed request from product/id/add_to_cart to /profile/cart
- added content-type to header
- passed product_id object in body

## Testing

 - [] npm run dev to run server
 - [] navigate to products and try adding a product to the cart
 - [] make sure cart displays item in cart

## Related Issues
Fixes https://github.com/orgs/NSS-Day-Cohort-79/projects/32/views/1?pane=issue&itemId=179034814&issue=NSS-Day-Cohort-79%7CBangazon-api-vezglj%7C56