### PR TITLE
User should be able to filter products by category

### DIFF
--- a/components/filter.js
+++ b/components/filter.js
@@ -15,11 +15,7 @@ export default function Filter({ productCount, onSearch, locations }) {
 
   const [showFilters, setShowFilters] = useState(false);
   const [query, setQuery] = useState("");
-  const [categories, setCategories] = useState([
-    { id: 1, name: "Apples" },
-    { id: 2, name: "Oranges" },
-    { id: 3, name: "Lemons" },
-  ]);
+  const [categories, setCategories] = useState([]);
   const [direction, setDirection] = useState("asc");
   const clear = () => {
     for (let ref in refEls) {
@@ -60,7 +56,7 @@ export default function Filter({ productCount, onSearch, locations }) {
     if (query) {
       onSearch(query);
     }
-  }, [query]);
+  }, [query, onSearch]);
 
   const buildQuery = (key, value) => {
     if (value && value !== "0") {

--- a/components/filter.js
+++ b/components/filter.js
@@ -58,6 +58,15 @@ export default function Filter({ productCount, onSearch, locations }) {
     }
   }, [query, onSearch]);
 
+  useEffect(() => {
+    getCategories().then((data) => {
+      console.log(data)
+      if (data) {
+        setCategories(data)
+      }
+    })
+  }, []);
+
   const buildQuery = (key, value) => {
     if (value && value !== "0") {
       return `${key}=${value}&`;

--- a/data/products.js
+++ b/data/products.js
@@ -15,7 +15,7 @@ export function getProducts(query = undefined) {
 }
 
 export function getCategories() {
-  return fetchWithResponse("categories", {
+  return fetchWithResponse("productcategories", {
     headers: {
       Authorization: `Token ${localStorage.getItem("token")}`,
     },


### PR DESCRIPTION
Given a user has clicked the Filter Products button on the product list view
When the user clicks the Filter by Category dropdown
Then all product categories should be presented as options instead of the dummy fruit names currently being used

Given the user clicks the Filter by Category dropdown
When the user chooses a product category
And clicks the Filter button
Then the product list should be filtered to products in that category

## Changes

- Removed fruit categories from useState in components/filter.js
- added UseEffect to get and set categories in compnonets/filter.js
- added onSearch to dependency array on line 59
- changed categories to productcategories in fetch request getCategories in data/products.js

## Requests / Responses
no changes this is for client-side 

## Testing

After testing api side:
- [x] navigate to products page
- [x] open filter drop down
- [ ] filter by auto, tools, and clothes (other categories do not have items so they should show blank pages)


## Related Issues

- Fixes #30 