### PR TITLE
completed order and listed orders

### DIFF
--- a/components/order/form-modal.js
+++ b/components/order/form-modal.js
@@ -7,7 +7,9 @@ export default function CompleteFormModal({
   paymentTypes,
   completeOrder,
 }) {
+
   const [selectedPayment, setSelectedPayment] = useState(0);
+  
   return (
     <Modal
       showModal={showModal}

--- a/data/orders.js
+++ b/data/orders.js
@@ -16,14 +16,14 @@ export function getOrders() {
   });
 }
 
-export function completeCurrentOrder(orderId, paymentTypeId) {
-  return fetchWithResponse(`orders/${orderId}/complete`, {
+export function completeCurrentOrder(orderId, payment_type) {
+  return fetchWithResponse(`orders/${orderId}`, {
     method: "PUT",
     headers: {
       Authorization: `Token ${localStorage.getItem("token")}`,
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ paymentTypeId }),
+    body: JSON.stringify({ payment_type }),
   });
 }
 

--- a/pages/cart.js
+++ b/pages/cart.js
@@ -54,18 +54,25 @@ export default function Cart() {
         paymentTypes={paymentTypes}
         completeOrder={completeOrder}
       />
-      <CardLayout title="Your Current Order">
-        <CartDetail cart={cart} removeProduct={removeProduct} />
-        <>
-          <a
-            className="card-footer-item"
-            onClick={() => setShowCompleteForm(true)}
-          >
-            Complete Order
-          </a>
-          <a className="card-footer-item" onClick={() => deleteCart()}>Delete Order</a>
-        </>
-      </CardLayout>
+      {cart?.id ? (
+        <CardLayout title="Your Current Order">
+          <CartDetail cart={cart} removeProduct={removeProduct} />
+          <>
+            <a
+              className="card-footer-item"
+              onClick={() => setShowCompleteForm(true)}
+            >
+              Complete Order
+            </a>
+            <a className="card-footer-item" onClick={() => deleteCart()}>Delete Order</a>
+          </>
+        </CardLayout>
+      ) : (
+           <CardLayout title="Your Cart is Empty">
+          <CartDetail cart={cart} removeProduct={removeProduct} />
+          <></>
+        </CardLayout>
+      )}
     </>
   );
 }

--- a/pages/my-orders.js
+++ b/pages/my-orders.js
@@ -21,7 +21,7 @@ export default function Orders() {
     <>
       <CardLayout title="Your Orders">
         <Table headers={headers}>
-          {orders.map((order) => (
+          {orders.filter((order) => (order.completed_on)).map((order) => (
             <tr key={order.id}>
               <td>{order.completed_on}</td>
               <td>${order.total}</td>

--- a/pages/my-orders.js
+++ b/pages/my-orders.js
@@ -25,7 +25,7 @@ export default function Orders() {
             <tr key={order.id}>
               <td>{order.completed_on}</td>
               <td>${order.total}</td>
-              <td>{order.payment_type?.obscured_num}</td>
+              <td>{order.payment_type?.merchant_name}</td>
             </tr>
           ))}
         </Table>


### PR DESCRIPTION
When a user clicks on the My Orders nav item, the correct number of rows in the table are created, but no information about the orders is displayed.

When the user clicks Complete Order from the cart view, and then selects a payment type, and then clicks on the Complete Order button on that dialog, the order does not complete. It is expected for the order to be marked as complete so that it shows up in the My Orders view and the cart is emptied.

## Changes

- Changed data/orders.js completeCurrentOrder. Changed payment type params to match correct backend and removed /complete 
- added logic to check if cart has id, if yes show active order, if not show your cart is empty. This handles the bug where the empty cart was still returning preventing the user from adding to a new order
- changed pages/my-orders.js to show merchant name in payment instead of url

## Requests / Responses

client side issues only for this PR

## Testing

Description of how to test code...

- [ ] Navigate to cart
- [ ] If items in cart add 1-2 more, if none add 1-2
- [ ] complete order by adding payment type
- [ ] add new items to cart to make sure a new cart is created
- [ ] make sure past orders are listed upon order completion 
